### PR TITLE
Support tooltip on duplicate categories false

### DIFF
--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import sortBy from 'lodash/sortBy';
+import get from 'lodash/get';
 import { useAppSelector } from '../hooks';
 import { RechartsRootState } from '../store';
 import {
@@ -210,7 +211,20 @@ export const combineTooltipPayload = (
     const finalNameKey: DataKey<any> | undefined = settings?.nameKey; // ?? tooltipAxis?.nameKey;
     let tooltipPayload: unknown;
     if (tooltipAxis?.dataKey && !tooltipAxis?.allowDuplicatedCategory && Array.isArray(sliced)) {
-      tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);
+      if (activeLabel || !sliced?.length) {
+        tooltipPayload = findEntryInArray(
+          sliced,
+          entry => {
+            if (!Array.isArray(entry)) {
+              return get(entry, tooltipAxis.dataKey as string);
+            }
+            return entry.find((item: any) => item.dataKey === tooltipAxis.dataKey)?.value;
+          },
+          activeLabel,
+        );
+      } else {
+        tooltipPayload = tooltipPayloadSearcher(sliced, activeIndex, computedData, finalNameKey);
+      }
     } else {
       tooltipPayload = tooltipPayloadSearcher(sliced, activeIndex, computedData, finalNameKey);
     }

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -102,7 +102,22 @@ export function findEntryInArray<T>(
     return null;
   }
 
-  return ary.find(
+  return ary.find(entry => {
+    const c = typeof specifiedKey === 'function' ? specifiedKey(entry) : get(entry, specifiedKey);
+    return entry && c === specifiedValue;
+  });
+}
+
+export function findEntriesInArray<T>(
+  ary: ReadonlyArray<T>,
+  specifiedKey: number | string | ((entry: T) => unknown),
+  specifiedValue: unknown,
+) {
+  if (!ary || !ary.length) {
+    return null;
+  }
+
+  return ary.filter(
     entry =>
       entry && (typeof specifiedKey === 'function' ? specifiedKey(entry) : get(entry, specifiedKey)) === specifiedValue,
   );

--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -7,11 +7,14 @@ import {
   BarChart,
   CartesianGrid,
   ComposedChart,
+  Legend,
   Line,
   LineChart,
   RadialBar,
   RadialBarChart,
   ResponsiveContainer,
+  Scatter,
+  ScatterChart,
   Tooltip,
   XAxis,
   YAxis,
@@ -467,5 +470,38 @@ export const RechartsAlphaTooltipBug5516ReproButWithItemBasedTooltip = {
         </div>
       </div>
     );
+  },
+};
+
+export const CustomTooltipAndDuplicateCategories = {
+  render: (args: Record<string, any>) => {
+    const data = [
+      { x: 100, y: 100, z: 200 },
+      { x: 100, y: 200, z: 200 },
+      { x: 100, y: 300, z: 200 },
+    ];
+
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <ScatterChart
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+        >
+          <CartesianGrid />
+          <XAxis type="category" allowDuplicatedCategory={false} dataKey="x" name="stature" unit="cm" />
+          <YAxis type="category" allowDuplicatedCategory={false} dataKey="y" name="weight" unit="kg" />
+          <Scatter activeShape={args.activeShape} name="A school" data={data} fill="#8884d8" />
+          <Tooltip shared={false} cursor={{ strokeDasharray: '3 3' }} />
+          <Legend />
+        </ScatterChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    activeShape: { fill: 'red' },
   },
 };


### PR DESCRIPTION
In case we have scatter chart and the X values are categories, and we have duplicates, the tooltip is not working correctly.